### PR TITLE
feat: support arithmetic expression in constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+## [1.0.7] - 2025-10-18
+- Add arithmetic expression support in constant definitions (operators: `+`, `-`, `*`, `/`, `%`, minus, and parentheses)
+- Add unresolved reference highlighting for constants used in expressions
 - Add quick fix to remove unused or invalid `#include` directives
 
 ## [1.0.6] - 2025-08-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [Unreleased]
 
 ## [1.0.7] - 2025-10-18
-- Add arithmetic expression support in constant definitions (operators: `+`, `-`, `*`, `/`, `%`, minus, and parentheses)
+- Add arithmetic expression support in constant definitions (operators: `+`, `-`, `*`, `/`, `%`)
 - Add unresolved reference highlighting for constants used in expressions
 - Add quick fix to remove unused or invalid `#include` directives
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,7 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            ide("IC-2025.2.3")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.github.com.cakevm.intellij_huff_plugin
 pluginName = Huff Language
 pluginRepositoryUrl = https://github.com/cakevm/intellij-huff-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 1.0.6
+pluginVersion = 1.0.7
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 251

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ pluginSinceBuild = 251
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 # IC = IntelliJ Community Edition
 platformType = IC
-platformVersion = 2025.1.5
+platformVersion = 2025.2.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/src/main/grammars/HuffLexer.flex
+++ b/src/main/grammars/HuffLexer.flex
@@ -71,6 +71,10 @@ NAT_SPEC_TAG=@[a-zA-Z_0-9:]*
   ":"                        { return COLON; }
   "<"                        { return LESS_THAN; }
   ">"                        { return GREATER_THAN; }
+  "+"                        { return PLUS; }
+  "-"                        { return MINUS; }
+  "*"                        { return STAR; }
+  "%"                        { return PERCENT; }
 
   "/*"                       {
                                yybegin(IN_BLOCK_COMMENT);
@@ -81,6 +85,7 @@ NAT_SPEC_TAG=@[a-zA-Z_0-9:]*
                                yybegin(IN_EOL_COMMENT);
                                yypushback(2);
                              }
+  "/"                        { return SLASH; }
 
   "#include"                 { return INCLUDE; }
   "#define"                  { return DEFINE; }

--- a/src/main/grammars/HuffParser.bnf
+++ b/src/main/grammars/HuffParser.bnf
@@ -28,6 +28,13 @@
     LESS_THAN='<'
     GREATER_THAN='>'
 
+    // Arithmetic operators
+    PLUS='+'
+    MINUS='-'
+    STAR='*'
+    SLASH='/'
+    PERCENT='%'
+
     // Huff specific
     INCLUDE='#include'
     DEFINE='#define'
@@ -131,8 +138,29 @@ private DefineDefinition ::= DEFINE ( EventAbiDefinition | FunctionAbiDefinition
 
 // #define constant
 ConstantDefinitionIdentifier ::= Identifier
-ConstantDefinitionAssignment ::= BuiltinFn | FREE_STORAGE_POINTER | HEXCODE | MacroIdentifier
-ConstantDefinition ::= CONSTANT ConstantDefinitionIdentifier EQUAL ConstantDefinitionAssignment {
+
+// Constant expressions with arithmetic operators
+ConstantExpression ::= AdditiveExpression
+
+private AdditiveExpression ::= MultiplicativeExpression ((PLUS | MINUS) MultiplicativeExpression)*
+
+private MultiplicativeExpression ::= UnaryExpression ((STAR | SLASH | PERCENT) UnaryExpression)*
+
+private UnaryExpression ::= MINUS? PrimaryExpression
+
+ConstantReferenceExpression ::= Identifier
+{
+  implements = "com.github.com.cakevm.intellij_huff_plugin.language.psi.element.HuffReferenceElement"
+  mixin      = "com.github.com.cakevm.intellij_huff_plugin.language.psi.mixin.HuffConstantReferenceExpressionMixin"
+}
+
+private PrimaryExpression ::= HEXCODE
+                           | ConstantReferenceExpression
+                           | BuiltinFn
+                           | FREE_STORAGE_POINTER
+                           | L_PAREN ConstantExpression R_PAREN
+
+ConstantDefinition ::= CONSTANT ConstantDefinitionIdentifier EQUAL ConstantExpression {
   implements         = "com.github.com.cakevm.intellij_huff_plugin.language.psi.element.HuffCallableElement"
   mixin              = "com.github.com.cakevm.intellij_huff_plugin.language.psi.mixin.HuffConstantDefinitionMixin"
   stubClass          = "com.github.com.cakevm.intellij_huff_plugin.language.psi.stub.impl.HuffConstantDefinitionStub"

--- a/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/ide/colors/HuffColors.kt
+++ b/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/ide/colors/HuffColors.kt
@@ -17,6 +17,7 @@ enum class HuffColor(humanName: Supplier<@AttributeDescriptor String>, default: 
   DEFINE(HuffBundle.messagePointer("settings.huff.color.define"), Default.KEYWORD),
   INCLUDE(HuffBundle.messagePointer("settings.huff.color.include"), Default.CLASS_REFERENCE),
   BRACES(HuffBundle.messagePointer("settings.huff.color.braces"), Default.BRACES),
+  OPERATOR(HuffBundle.messagePointer("settings.huff.color.operator"), Default.OPERATION_SIGN),
   BUILTIN_FN(HuffBundle.messagePointer("settings.huff.color.builtin_fn"), Default.STATIC_METHOD),
   ARITHMETIC_AND_LOGICAL(HuffBundle.messagePointer("settings.huff.color.arithmetic_and_logical"), Default.HIGHLIGHTED_REFERENCE),
   STACK_MANAGEMENT(HuffBundle.messagePointer("settings.huff.color.stack_management"), Default.HIGHLIGHTED_REFERENCE),

--- a/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/ide/highlight/HuffHighlighter.kt
+++ b/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/ide/highlight/HuffHighlighter.kt
@@ -39,6 +39,12 @@ class HuffHighlighter : SyntaxHighlighterBase() {
         INCLUDE to HuffColor.INCLUDE,
         L_BRACE to HuffColor.BRACES,
         R_BRACE to HuffColor.BRACES,
+        // Arithmetic operators
+        PLUS to HuffColor.OPERATOR,
+        MINUS to HuffColor.OPERATOR,
+        STAR to HuffColor.OPERATOR,
+        SLASH to HuffColor.OPERATOR,
+        PERCENT to HuffColor.OPERATOR,
       )
       .plus(buildInFns().map { it to HuffColor.BUILTIN_FN })
       .plus(opcodeNamesStackManagement().map { it to HuffColor.STACK_MANAGEMENT })

--- a/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/ide/inspection/HuffResolveNameInspection.kt
+++ b/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/ide/inspection/HuffResolveNameInspection.kt
@@ -55,6 +55,12 @@ class HuffResolveNameInspection : LocalInspectionTool() {
         }
       }
 
+      override fun visitConstantReferenceExpression(element: HuffConstantReferenceExpression) {
+        checkReference(element) {
+          holder.registerProblem(element, "'${element.identifier.text}' constant is undefined", ProblemHighlightType.WARNING)
+        }
+      }
+
       override fun visitMacroCall(element: HuffMacroCall) {
         checkReference(element) {
           if (builtinFns[element.macroCallIdentifier.text] == null) {

--- a/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/language/psi/mixin/HuffConstantReferenceExpressionMixin.kt
+++ b/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/language/psi/mixin/HuffConstantReferenceExpressionMixin.kt
@@ -1,0 +1,21 @@
+package com.github.com.cakevm.intellij_huff_plugin.language.psi.mixin
+
+import com.github.com.cakevm.intellij_huff_plugin.language.psi.HuffConstantReferenceExpression
+import com.github.com.cakevm.intellij_huff_plugin.language.psi.impl.HuffNamedElementImpl
+import com.github.com.cakevm.intellij_huff_plugin.language.reference.HuffConstantReferenceExpressionReference
+import com.github.com.cakevm.intellij_huff_plugin.language.reference.base.HuffReference
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+
+abstract class HuffConstantReferenceExpressionMixin(node: ASTNode) : HuffNamedElementImpl(node), HuffConstantReferenceExpression {
+
+  override val referenceNameElement: PsiElement
+    get() = this.identifier
+
+  override val referenceName: String
+    get() = referenceNameElement.text
+
+  override fun getName(): String? = referenceName
+
+  override fun getReference(): HuffReference = HuffConstantReferenceExpressionReference(this as HuffConstantReferenceExpression)
+}

--- a/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/language/reference/HuffConstantReferenceExpressionReference.kt
+++ b/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/language/reference/HuffConstantReferenceExpressionReference.kt
@@ -1,0 +1,24 @@
+package com.github.com.cakevm.intellij_huff_plugin.language.reference
+
+import com.github.com.cakevm.intellij_huff_plugin.language.psi.HuffConstantReferenceExpression
+import com.github.com.cakevm.intellij_huff_plugin.language.psi.element.HuffNamedElement
+import com.github.com.cakevm.intellij_huff_plugin.language.psi.parentRelativeRange
+import com.github.com.cakevm.intellij_huff_plugin.language.reference.base.HuffReference
+import com.github.com.cakevm.intellij_huff_plugin.language.reference.base.HuffReferenceBase
+import com.intellij.openapi.util.TextRange
+
+class HuffConstantReferenceExpressionReference(element: HuffConstantReferenceExpression) :
+  HuffReferenceBase<HuffConstantReferenceExpression>(element), HuffReference {
+
+  override fun calculateDefaultRangeInElement(): TextRange {
+    return element.referenceNameElement.parentRelativeRange
+  }
+
+  override fun multiResolve(): Collection<HuffNamedElement> {
+    return HuffResolver.resolveTypeNameUsingImports(this.element)
+  }
+
+  override fun resolve(): HuffNamedElement? {
+    return this.multiResolve().firstOrNull()
+  }
+}

--- a/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/language/reference/HuffResolver.kt
+++ b/src/main/kotlin/com/github/com/cakevm/intellij_huff_plugin/language/reference/HuffResolver.kt
@@ -28,6 +28,9 @@ object HuffResolver {
           is HuffMacroConstantReference -> {
             resolveUsingImports(HuffConstantDefinition::class.java, element, element.containingFile)
           }
+          is HuffConstantReferenceExpression -> {
+            resolveUsingImports(HuffConstantDefinition::class.java, element, element.containingFile)
+          }
           is HuffBuiltinFnFuncSigCall -> {
             resolveUsingImports(HuffFunctionAbiDefinition::class.java, element, element.containingFile)
           }

--- a/src/main/resources/messages/HuffBundle.properties
+++ b/src/main/resources/messages/HuffBundle.properties
@@ -12,6 +12,7 @@ settings.huff.color.number=Number
 settings.huff.color.define=#define
 settings.huff.color.include=include
 settings.huff.color.braces=Symbols//Braces
+settings.huff.color.operator=Symbols//Operators
 settings.huff.color.builtin_fn=Build-in function
 settings.huff.color.arithmetic_and_logical=Arithmetic and logical operators
 settings.huff.color.stack_management=Stack management


### PR DESCRIPTION
- Add arithmetic expression support in constant definitions (operators: `+`, `-`, `*`, `/`, `%`)
- Add unresolved reference highlighting for constants used in expressions